### PR TITLE
turn off doc building by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ the tools listed below should be enough to successfully execute this script:
 - `m4`, which is required to execute `configure` scripts,
 - `curl`, used to download the source tarballs of toolchain components,
 - `tar`, used to extract source tarballs and to compress compiled toolchain,
-- `texinfo` and `texlive`, used to generate documentation,
+- `texinfo` and `texlive`, (optional) used to generate documentation,
 - `python`, required by GDB, may be either version 2 or 3, but should contain headers and libraries, so you may need
 some kind of "development" and/or "library" package, depending on your system.
 
 Exact set of required packages will be different on each system, but on a fresh Ubuntu installation you are going to
-need just these packages: `curl`, `m4`, `python2.7-dev`, `texinfo` and `texlive`.
+need just these packages: `curl`, `m4`, `python2.7-dev` and optionally: `texinfo` and `texlive`.
 
 Toolchain for Windows
 ---------------------
@@ -54,5 +54,6 @@ Additional options
 
 - `--keep-build-folders` will cause all build folders to be left intact after the build, by default - if this option is
 not provided - all build folders are removed as soon as they are not needed anymore;
+- `--skip-documentation` will skip building html/pdf documentation in the subprojects, by default - if this option is not provided - the documentation is built, requiring texlive/texinfo;
 - `--skip-nano-libraries` will skip building of "nano" libraries, by default - if this option is not provided - "nano"
 libraries will be built, making the whole process significantly longer;

--- a/build-bleeding-edge-toolchain.sh
+++ b/build-bleeding-edge-toolchain.sh
@@ -77,6 +77,7 @@ enableWin32="n"
 enableWin64="n"
 keepBuildFolders="n"
 skipNanoLibraries="n"
+buildDocumentation="y"
 while [ ${#} -gt 0 ]; do
 	case ${1} in
 		--enable-win32)
@@ -88,16 +89,24 @@ while [ ${#} -gt 0 ]; do
 		--keep-build-folders)
 			keepBuildFolders="y"
 			;;
+		--skip-documentation)
+			buildDocumentation="n"
+			;;
 		--skip-nano-libraries)
 			skipNanoLibraries="y"
 			;;
 
 		*)
-			echo "Usage: $0 [--enable-win32] [--enable-win64] [--keep-build-folders] [--skip-nano-libraries]" >&2
+			echo "Usage: $0 [--enable-win32] [--enable-win64] [--keep-build-folders] [--skip-documentation] [--skip-nano-libraries]" >&2
 			exit 1
 	esac
 	shift
 done
+
+documentationTypes=""
+if [ ${buildDocumentation} = "y" ]; then
+	documentationTypes="html pdf"
+fi
 
 buildZlib() {
 	(
@@ -670,7 +679,7 @@ buildIsl ${buildNative} "" ""
 
 buildExpat ${buildNative} "" ""
 
-buildBinutils ${buildNative} ${installNative} "" "" "html pdf"
+buildBinutils ${buildNative} ${installNative} "" "" "${documentationTypes}"
 
 buildGcc ${buildNative} ${installNative} "" "--enable-languages=c --without-headers"
 
@@ -701,15 +710,17 @@ buildNewlib \
 		--enable-newlib-io-c99-formats \
 		--enable-newlib-io-long-long \
 		--disable-newlib-atexit-dynamic-alloc" \
-	"html pdf"
+	"${documentationTypes}"
 
-buildGccFinal "-final" "-O2" "${installNative}" "html pdf"
+buildGccFinal "-final" "-O2" "${installNative}" "${documentationTypes}"
 
-buildGdb ${buildNative} ${installNative} "" "--with-python=yes" "html pdf"
+buildGdb ${buildNative} ${installNative} "" "--with-python=yes" "${documentationTypes}"
 
 postCleanup ${installNative} "" "$(uname -mo)" ""
 find ${installNative} -type f -executable -exec strip {} \; || true
-find ${installNative}/share/doc -mindepth 2 -name '*.pdf' -exec mv {} ${installNative}/share/doc \;
+if [ ${buildDocumentation} = "y" ]; then
+	find ${installNative}/share/doc -mindepth 2 -name '*.pdf' -exec mv {} ${installNative}/share/doc \;
+fi
 
 echo "${bold}********** Package${normal}"
 rm -rf ${package}


### PR DESCRIPTION
It's already disabled for cross builds, disable it for native builds too
unless requested.  Eliminates the entire texlive/latex requirement in
most cases.