### PR TITLE
Always check that downloads are complete

### DIFF
--- a/build-bleeding-edge-toolchain.sh
+++ b/build-bleeding-edge-toolchain.sh
@@ -605,9 +605,18 @@ echo "${bold}********** Download${normal}"
 mkdir -p ${sources}
 cd ${sources}
 download() {
-	if [ ! -e ${1} ]; then
-		echo "${bold}---------- Downloading ${1}${normal}"
-		curl -L -o ${1} -C - ${2}
+	echo "${bold}---------- Downloading ${1}${normal}"
+	RET=0
+	curl -L -o ${1} -C - ${2} || RET=$?
+	if [ $RET -eq 0 ]
+	then
+		true
+	elif [ $RET -ne 33 ]
+	then
+		echo $RET
+		exit $RET
+	else
+		echo This happens if the file is complete, continuing
 	fi
 }
 download ${binutilsArchive} ftp://ftp.gnu.org/gnu/binutils/${binutilsArchive}


### PR DESCRIPTION
curl can leave partial downloads after network errors and the script will not retry (despite -C -) due to `if ! -e $1` on the previous line

This pullreq makes curl always retry, since we don't have upstream filesize information available to compare against `stat -c %s $1`

Since curl returns error code 33 when the file is complete (claiming that server doesn't seem to support byte ranges), we trap this error, consider it a success, and continue