### PR TITLE
Further improve quiet build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `--quiet-build` option, which will make the build quiet(er).
+- `--quiet` option, which will make the build quiet(er).
 - `--resume` option, which will try to resume the last build.
 
 ### Changed

--- a/build-bleeding-edge-toolchain.sh
+++ b/build-bleeding-edge-toolchain.sh
@@ -86,7 +86,7 @@ enableWin64="n"
 keepBuildFolders="n"
 skipNanoLibraries="n"
 buildDocumentation="y"
-quietBuild="n"
+quiet="n"
 resume="n"
 while [ ${#} -gt 0 ]; do
 	case ${1} in
@@ -105,15 +105,15 @@ while [ ${#} -gt 0 ]; do
 		--skip-nano-libraries)
 			skipNanoLibraries="y"
 			;;
-		--quiet-build)
-			quietBuild="y"
+		--quiet)
+			quiet="y"
 			;;
 		--resume)
 			resume="y"
 			;;
 
 		*)
-			echo "Usage: $0 [--enable-win32] [--enable-win64] [--keep-build-folders] [--skip-documentation] [--skip-nano-libraries] [--quiet-build] [--resume]" >&2
+			echo "Usage: $0 [--enable-win32] [--enable-win64] [--keep-build-folders] [--skip-documentation] [--skip-nano-libraries] [--quiet] [--resume]" >&2
 			exit 1
 	esac
 	shift
@@ -125,7 +125,7 @@ if [ ${buildDocumentation} = "y" ]; then
 fi
 
 quietConfigureOptions=""
-if [ ${quietBuild} = "y" ]; then
+if [ ${quiet} = "y" ]; then
 	quietConfigureOptions="--quiet --enable-silent-rules"
 fi
 

--- a/build-bleeding-edge-toolchain.sh
+++ b/build-bleeding-edge-toolchain.sh
@@ -127,6 +127,8 @@ fi
 quietConfigureOptions=""
 if [ ${quiet} = "y" ]; then
 	quietConfigureOptions="--quiet --enable-silent-rules"
+	export MAKEFLAGS="--quiet"
+	export GNUMAKEFLAGS="--quiet"
 fi
 
 BASE_CPPFLAGS="-pipe"


### PR DESCRIPTION
I renamed the option to "--quiet".

Also I set the environment variable "MAKEFLAGS" to "--quiet".
It will propagate to all make's started directly or via the build systems (e.g. newlib).
This will make the build even more quiet.